### PR TITLE
Fix nested sync folder creation

### DIFF
--- a/main.js
+++ b/main.js
@@ -168,9 +168,14 @@ var WhatsAppVoiceSyncPlugin = class extends import_obsidian.Plugin {
   async ensureSyncFolderExists() {
     if (!this.settings.syncFolder)
       return;
-    const folder = this.app.vault.getAbstractFileByPath(this.settings.syncFolder);
-    if (!folder) {
-      await this.app.vault.createFolder(this.settings.syncFolder);
+    const parts = this.settings.syncFolder.split("/");
+    let currentPath = "";
+    for (const part of parts) {
+      currentPath = currentPath ? `${currentPath}/${part}` : part;
+      const folder = this.app.vault.getAbstractFileByPath(currentPath);
+      if (!folder) {
+        await this.app.vault.createFolder(currentPath);
+      }
     }
   }
   async saveVoiceNote(note) {

--- a/main.ts
+++ b/main.ts
@@ -196,14 +196,21 @@ export default class WhatsAppVoiceSyncPlugin extends Plugin {
 		});
 	}
 
-	private async ensureSyncFolderExists(): Promise<void> {
-		if (!this.settings.syncFolder) return;
+        private async ensureSyncFolderExists(): Promise<void> {
+                if (!this.settings.syncFolder) return;
 
-		const folder = this.app.vault.getAbstractFileByPath(this.settings.syncFolder);
-		if (!folder) {
-			await this.app.vault.createFolder(this.settings.syncFolder);
-		}
-	}
+                // Ensure each level of the path exists since Vault.createFolder
+                // doesn't create parent folders automatically
+                const parts = this.settings.syncFolder.split('/');
+                let currentPath = '';
+                for (const part of parts) {
+                        currentPath = currentPath ? `${currentPath}/${part}` : part;
+                        const folder = this.app.vault.getAbstractFileByPath(currentPath);
+                        if (!folder) {
+                                await this.app.vault.createFolder(currentPath);
+                        }
+                }
+        }
 
 	private async saveVoiceNote(note: VoiceNote): Promise<boolean> {
 		try {


### PR DESCRIPTION
## Summary
- ensure sync folder path is created recursively so nested directories are handled
- rebuild plugin bundle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894e2e6150c8327ac632d9cc546b5d6