### PR TITLE
Handle API errors when marking voice notes processed

### DIFF
--- a/main.js
+++ b/main.js
@@ -157,13 +157,16 @@ var WhatsAppVoiceSyncPlugin = class extends import_obsidian.Plugin {
     return await response.json();
   }
   async markNoteAsProcessed(noteId) {
-    await fetch(`${this.settings.jarvisBotUrl}/api/voice-notes/${noteId}/processed`, {
+    const response = await fetch(`${this.settings.jarvisBotUrl}/api/voice-notes/${noteId}/processed`, {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${this.settings.apiKey}`,
         "Content-Type": "application/json"
       }
     });
+    if (!response.ok) {
+      throw new Error(`Failed to mark note as processed: HTTP ${response.status} ${response.statusText}`);
+    }
   }
   async ensureSyncFolderExists() {
     if (!this.settings.syncFolder)

--- a/main.ts
+++ b/main.ts
@@ -187,14 +187,18 @@ export default class WhatsAppVoiceSyncPlugin extends Plugin {
 	}
 
 	private async markNoteAsProcessed(noteId: string): Promise<void> {
-		await fetch(`${this.settings.jarvisBotUrl}/api/voice-notes/${noteId}/processed`, {
-			method: 'POST',
-			headers: {
-				'Authorization': `Bearer ${this.settings.apiKey}`,
-				'Content-Type': 'application/json'
-			}
-		});
-	}
+                const response = await fetch(`${this.settings.jarvisBotUrl}/api/voice-notes/${noteId}/processed`, {
+                        method: 'POST',
+                        headers: {
+                                'Authorization': `Bearer ${this.settings.apiKey}`,
+                                'Content-Type': 'application/json'
+                        }
+                });
+
+                if (!response.ok) {
+                        throw new Error(`Failed to mark note as processed: HTTP ${response.status} ${response.statusText}`);
+                }
+        }
 
         private async ensureSyncFolderExists(): Promise<void> {
                 if (!this.settings.syncFolder) return;


### PR DESCRIPTION
## Summary
- Capture response from markNoteAsProcessed API call
- Throw error when the API returns a non-OK status

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894e79ea8848327992f196b521a408c