### PR TITLE
docs: remove styles.css references

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm install
 npm run build
 ```
 
-Copy the built files (`main.js`, `manifest.json`, `styles.css`) to your Obsidian plugins directory.
+Copy the built files (`main.js`, `manifest.json`) to your Obsidian plugins directory.
 
 ### Configuration
 
@@ -208,7 +208,6 @@ npm run typecheck  # Type checking
 ```
 ├── main.ts           # Main plugin code
 ├── manifest.json     # Plugin manifest
-├── styles.css        # Plugin styles
 ├── package.json      # Dependencies
 └── README.md         # This file
 ```


### PR DESCRIPTION
## Summary
- remove styles.css from build instructions
- update project structure to omit unused stylesheet

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6894e7a0521c8327ab4756f2d9232cf2